### PR TITLE
Correct spelling of OpenStack

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ storage apis. Supported apis include:
 
 - SOH
 - S3
-- Openstack
+- OpenStack
 - WebDAV
 
 ## Build


### PR DESCRIPTION
OpenStack has a capital "s" in it.