### PR TITLE
Upgrade Log4J 2.16.0 to 2.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,19 +150,19 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.15.0</version>
+        <version>2.17.0</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.15.0</version>
+        <version>2.17.0</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-slf4j-impl</artifactId>
-        <version>2.15.0</version>
+        <version>2.17.0</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
Motivation:

Log4J upgrade to address a security risk CVE-2021-45105

Modifications:

Upgrade from 2.16.0 to 2.17.0

Result:

Using a safer Log4J version