### PR TITLE
Fix five serialization flaky tests

### DIFF
--- a/og-configuration/src/test/java/com/ibm/og/json/type/ChoiceConfigTypeAdapterFactoryTest.java
+++ b/og-configuration/src/test/java/com/ibm/og/json/type/ChoiceConfigTypeAdapterFactoryTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 
 import com.ibm.og.json.ChoiceConfig;
 import com.google.gson.Gson;
+import com.google.gson.JsonParser;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 
@@ -94,6 +95,7 @@ public class ChoiceConfigTypeAdapterFactoryTest {
   @Test
   public void serialization() {
     final ChoiceConfig<Double> config = new ChoiceConfig<Double>(15.0);
-    assertThat(this.gson.toJson(config), is(new GsonBuilder().create().toJson(config)));
+    JsonParser parser = new JsonParser();
+    assertThat(parser.parse(this.gson.toJson(config)), is(parser.parse(new GsonBuilder().create().toJson(config))));
   }
 }

--- a/og-configuration/src/test/java/com/ibm/og/json/type/ContainerConfigTypeAdapterFactoryTest.java
+++ b/og-configuration/src/test/java/com/ibm/og/json/type/ContainerConfigTypeAdapterFactoryTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
+import com.google.gson.JsonParser;
 import com.ibm.og.json.SelectionType;
 import org.hamcrest.Matchers;
 import org.junit.Before;
@@ -59,6 +60,7 @@ public class ContainerConfigTypeAdapterFactoryTest {
   public void serialization() {
     final ContainerConfig config = new ContainerConfig("vault");
 
-    assertThat(this.gson.toJson(config), is(new GsonBuilder().create().toJson(config)));
+    JsonParser parser = new JsonParser();
+    assertThat(parser.parse(this.gson.toJson(config)), is(parser.parse(new GsonBuilder().create().toJson(config))));
   }
 }

--- a/og-configuration/src/test/java/com/ibm/og/json/type/FilesizeConfigTypeAdapterFactoryTest.java
+++ b/og-configuration/src/test/java/com/ibm/og/json/type/FilesizeConfigTypeAdapterFactoryTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
+import com.google.gson.JsonParser;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -52,6 +53,7 @@ public class FilesizeConfigTypeAdapterFactoryTest {
   public void serialization() {
     final FilesizeConfig config = new FilesizeConfig(15.0);
 
-    assertThat(this.gson.toJson(config), is(new GsonBuilder().create().toJson(config)));
+    JsonParser parser = new JsonParser();
+    assertThat(parser.parse(this.gson.toJson(config)), is(parser.parse(new GsonBuilder().create().toJson(config))));
   }
 }

--- a/og-configuration/src/test/java/com/ibm/og/json/type/OperationConfigTypeAdapterFactoryTest.java
+++ b/og-configuration/src/test/java/com/ibm/og/json/type/OperationConfigTypeAdapterFactoryTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
+import com.google.gson.JsonParser;
 import com.ibm.og.json.OperationConfig;
 import org.junit.Before;
 import org.junit.Test;
@@ -52,6 +53,7 @@ public class OperationConfigTypeAdapterFactoryTest {
   public void serialization() {
     final OperationConfig config = new OperationConfig(75.0);
 
-    assertThat(this.gson.toJson(config), is(new GsonBuilder().create().toJson(config)));
+    JsonParser parser = new JsonParser();
+    assertThat(parser.parse(this.gson.toJson(config)), is(parser.parse(new GsonBuilder().create().toJson(config))));
   }
 }

--- a/og-configuration/src/test/java/com/ibm/og/json/type/SelectionConfigTypeAdapterFactoryTest.java
+++ b/og-configuration/src/test/java/com/ibm/og/json/type/SelectionConfigTypeAdapterFactoryTest.java
@@ -10,6 +10,7 @@ import static org.hamcrest.Matchers.equalToIgnoringCase;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
+import com.google.gson.JsonParser;
 import com.ibm.og.json.ChoiceConfig;
 import com.ibm.og.json.SelectionConfig;
 import com.ibm.og.json.SelectionType;
@@ -119,7 +120,8 @@ public class SelectionConfigTypeAdapterFactoryTest {
     final SelectionConfig<Double> config = new SelectionConfig<Double>();
     config.choices.add(new ChoiceConfig<Double>(15.0));
     // currently gson serializes enums in ALL CAPS, so we do a case insensitive compare here
-    assertThat(this.gson.toJson(config),
-        equalToIgnoringCase(new GsonBuilder().create().toJson(config)));
+    JsonParser parser = new JsonParser();
+    assertThat(parser.parse(this.gson.toJson(config).toUpperCase()),
+        is(parser.parse((new GsonBuilder().create().toJson(config).toUpperCase()))));
   }
 }


### PR DESCRIPTION
## The Issue

By using the plugin [NonDex](https://github.com/TestingResearchIllinois/NonDex), 5 tests

```
com.ibm.og.json.type.ChoiceConfigTypeAdapterFactoryTest.serialization
com.ibm.og.json.type.ContainerConfigTypeAdapterFactoryTest.serialization
com.ibm.og.json.type.FilesizeConfigTypeAdapterFactoryTest.serialization
com.ibm.og.json.type.OperationConfigTypeAdapterFactoryTest.serialization
com.ibm.og.json.type.SelectionConfigTypeAdapterFactoryTest.serialization
```

may fail in the future due to assuming a deterministic order of fields in serialization strings. The Java specification does not guarantee such an order, yet its current implementation assumes one. This plugin shuffles the ordering of fields, which cause these tests to fail when run without the plugin. The goal of the fix is to make sure that no false alarms were made for this reason.

## Reproduce Result

Here are the steps to reproduce the result:

```
git clone https://github.com/IBM/og && cd og
export JAVA_HOME=$(/usr/libexec/java_home -v1.8)
mvn clean install -pl og-configuration -am -DskipTests
mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex -pl og-configuration -Dtest=ChoiceConfigTypeAdapterFactoryTest#serialization -DnondexRuns=10
mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex -pl og-configuration -Dtest=ContainerConfigTypeAdapterFactoryTest#serialization -DnondexRuns=10
mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex -pl og-configuration -Dtest=FilesizeConfigTypeAdapterFactoryTest#serialization -DnondexRuns=10
mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex -pl og-configuration -Dtest=OperationConfigTypeAdapterFactoryTest#serialization -DnondexRuns=10
mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex -pl og-configuration -Dtest=SelectionConfigTypeAdapterFactoryTest#serialization -DnondexRuns=10
```

## The Fix

The current fix implemented deserializes the string and then compare them. Since these fixes rely on dependencies also used by the project, they do not introduce any new potential issues that are particular to the project itself, and can be trusted for their functionalities. The test in `SelectionConfigTypeAdapterFactoryTest` with case insensitiveness is also addressed.

Please do take a look and comment on whether this is a viable approach, hope to hear back from you soon :)